### PR TITLE
Removed configuration of unused Log ENV variables in tests

### DIFF
--- a/test/test_init.rb
+++ b/test/test_init.rb
@@ -1,14 +1,5 @@
 ENV['CONSOLE_DEVICE'] ||= 'stdout'
-ENV['LOG_COLOR'] ||= 'on'
-
-if ENV['LOG_LEVEL']
-  ENV['LOGGER'] ||= 'on'
-else
-  ENV['LOG_LEVEL'] ||= 'trace'
-end
-
-ENV['LOGGER'] ||= 'off'
-ENV['LOG_OPTIONAL'] ||= 'on'
+ENV['LOG_LEVEL'] ||= 'trace'
 
 puts RUBY_DESCRIPTION
 


### PR DESCRIPTION
Fixes #1 